### PR TITLE
Add simple Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM php:8.1-cli-alpine
+
+RUN $(php -r '$extensionInstalled = array_map("strtolower", \get_loaded_extensions(false));$requiredExtensions = ["zlib"];$extensionsToInstall = array_diff($requiredExtensions, $extensionInstalled);if ([] !== $extensionsToInstall) {echo \sprintf("docker-php-ext-install %s", implode(" ", $extensionsToInstall));}echo "echo \"No extensions\"";')
+
+COPY . /
+
+ENTRYPOINT ["/minicli"]


### PR DESCRIPTION
The documentation about [distributing the app as a docker image](https://docs.minicli.dev/en/latest/getting_started/using-docker/#production) provides an example Dockerfile based on php-fpm which produces a rather large image (~600 MB) that includes lots of stuff that isn't necessary for running the app.

This Dockerfile produces an image that is quite a bit smaller (~100 MB), is simpler and a lot faster to build.

Since minicli prides itself on being minimal and dependency free, I think it would be make sense to make it easy to create a minimal Docker image so the end users don't even need to have php installed.

The Dockerfile is heavily inspired by the one produced by https://github.com/owenvoke/laravel-zero-docker.